### PR TITLE
Fix typos, remove inapplicable instructions from dev docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Pkg
 
 # targeting the correct source code
-# this asumes the make.jl script is located in QEDcore.jl/docs
+# this assumes the make.jl script is located in QEDcore.jl/docs
 project_path = Base.Filesystem.joinpath(Base.Filesystem.dirname(Base.source_path()), "..")
 Pkg.develop(; path=project_path)
 

--- a/docs/src/10-interface.md
+++ b/docs/src/10-interface.md
@@ -45,7 +45,7 @@ t(::MyVector)
 You can inspect the required accessors for a given coordinate system using:
 
 ```julia
-coordinate_system(XYZT())  # returns (:x, :y, :z, :t)
+coordinate_names(XYZT())  # returns (:x, :y, :z, :t)
 ```
 
 This indicates which component accessors your type must implement to be compliant with that system.

--- a/docs/src/10-interface.md
+++ b/docs/src/10-interface.md
@@ -26,7 +26,7 @@ To make your type compliant with `LorentzVectorBase`, you must:
 Assign a coordinate system using:
 
 ```julia
-LorentzVectorBase.coordinate_system(::Type{MyVector}) = XYZT()
+LorentzVectorBase.coordinate_system(::MyVector) = XYZT()
 ```
 
 Coordinate systems are tagged using constructors like `XYZT()`, `PtEtaPhiE()`, etc. These indicate how the four components are interpreted.
@@ -155,7 +155,7 @@ struct MyVector
     E::Float64
 end
 
-LorentzVectorBase.coordinate_system(::Type{MyVector}) = XYZE()
+LorentzVectorBase.coordinate_system(::MyVector) = PxPyPzE()
 
 LorentzVectorBase.px(v::MyVector) = v.px
 LorentzVectorBase.py(v::MyVector) = v.py

--- a/docs/src/91-dev_docs.md
+++ b/docs/src/91-dev_docs.md
@@ -92,7 +92,6 @@ We try to keep a linear history in this repo, so it is important to keep your br
     Try to create "atomic git commits" (recommended reading: [The Utopic Git History](https://blog.esciencecenter.nl/the-utopic-git-history-d44b81c09593)).
 
 - Make sure the tests pass.
-- Make sure the pre-commit tests pass.
 - Fetch any `main` updates from upstream and rebase your branch, if necessary:
 
     ```bash
@@ -121,11 +120,6 @@ To create a new release, you can follow these simple steps:
 
 - Create a branch `release-x.y.z`
 - Update `version` in `Project.toml`
-- Update the `CHANGELOG.md`:
-    - Rename the section "Unreleased" to "[x.y.z] - yyyy-mm-dd" (i.e., version under brackets, dash, and date in ISO format)
-    - Add a new section on top of it named "Unreleased"
-    - Add a new link in the bottom for version "x.y.z"
-    - Change the "[unreleased]" link to use the latest version - end of line, `vx.y.z ... HEAD`.
 - Create a commit "Release vx.y.z", push, create a PR, wait for it to pass, merge the PR.
 - Go back to main screen and click on the latest commit (link: <https://github.com/JuliaHEP/LorentzVectorBase.jl/commit/main>)
 - At the bottom, write `@JuliaRegistrator register`

--- a/src/coordinate_systems/PtEtaPhiM.jl
+++ b/src/coordinate_systems/PtEtaPhiM.jl
@@ -108,7 +108,7 @@ end
 function mt(::PtEtaPhiM, mom)
   mT2 = mt2(mom)
   if mT2 < zero(mT2)
-    # add optional waring: negative transverse mass -> -sqrt(-mT2) is returned.
+    # add optional warning: negative transverse mass -> -sqrt(-mT2) is returned.
     -sqrt(-mT2)
   else
     sqrt(mT2)

--- a/src/coordinate_systems/XYZT.jl
+++ b/src/coordinate_systems/XYZT.jl
@@ -66,7 +66,7 @@ function z end
   return x(mom)^2 + y(mom)^2 + z(mom)^2
 end
 
-@inline function spatial_magnitude(cs::XYZT, mom)
+@inline function spatial_magnitude(::XYZT, mom)
   return sqrt(spatial_magnitude2(mom))
 end
 
@@ -124,7 +124,7 @@ end
 function mt(::XYZT, mom)
   mT2 = mt2(mom)
   if mT2 < zero(mT2)
-    # add optional waring: negative transverse mass -> -sqrt(-mT2) is returned.
+    # add optional warning: negative transverse mass -> -sqrt(-mT2) is returned.
     -sqrt(-mT2)
   else
     sqrt(mT2)

--- a/test/PxPyPzE.jl
+++ b/test/PxPyPzE.jl
@@ -25,7 +25,7 @@ mom_onshell = CustomMom(px, py, pz, E)
 mom_zero = CustomMom(0.0, 0.0, 0.0, 0.0)
 mom_offshell = CustomMom(0.0, 0.0, m, 0.0)
 
-@testset "cooridnate names" begin
+@testset "coordinate names" begin
   coordinate_names(LorentzVectorBase.PxPyPzE()) == (:px, :py, :pz, :E)
 end
 
@@ -89,7 +89,7 @@ end
   @test isapprox(LorentzVectorBase.boost_gamma(mom_zero), 1.0)
 end
 
-@testset "transverse coordiantes value" begin
+@testset "transverse coordinates value" begin
   @test isapprox(LorentzVectorBase.pt2(mom_onshell), px^2 + py^2)
   @test isapprox(LorentzVectorBase.pt(mom_onshell), sqrt(px^2 + py^2))
   @test isapprox(LorentzVectorBase.mt2(mom_onshell), E^2 - pz^2)
@@ -104,7 +104,7 @@ end
   @test isapprox(LorentzVectorBase.mt(mom_zero), 0.0)
 end
 
-@testset "spherical coordiantes consistence" for mom_on in [mom_onshell, mom_zero]
+@testset "spherical coordinates consistence" for mom_on in [mom_onshell, mom_zero]
   @test isapprox(
     LorentzVectorBase.cos_theta(mom_on), cos(LorentzVectorBase.polar_angle(mom_on))
   )
@@ -139,7 +139,7 @@ end
   @test LorentzVectorBase.azimuthal_angle(p) ≈ -ϕ
 end
 
-@testset "spherical coordiantes values" begin
+@testset "spherical coordinates values" begin
   @test isapprox(
     LorentzVectorBase.polar_angle(mom_onshell), atan(LorentzVectorBase.pt(mom_onshell), pz)
   )
@@ -149,7 +149,7 @@ end
   @test isapprox(LorentzVectorBase.phi(mom_zero), 0.0)
 end
 
-@testset "light-cone coordiantes" begin
+@testset "light-cone coordinates" begin
   @test isapprox(LorentzVectorBase.plus_component(mom_onshell), 0.5 * (E + pz))
   @test isapprox(LorentzVectorBase.minus_component(mom_onshell), 0.5 * (E - pz))
 

--- a/test/XYZT.jl
+++ b/test/XYZT.jl
@@ -23,7 +23,7 @@ t = sqrt(1 + x^2 + y^2 + z^2) # ensure a positive p*p
 lvec_non_zero = CustomLVector(x, y, z, t)
 lvec_zero = CustomLVector(0.0, 0.0, 0.0, 0.0)
 
-@testset "coordiante names" begin
+@testset "coordinate names" begin
   coordinate_names(LorentzVectorBase.XYZT()) == (:x, :y, :z, :E)
 end
 
@@ -94,7 +94,7 @@ end
   @test_throws ArgumentError LorentzVectorBase.boost_beta(CustomLVector(1, 1, 1, 0))
 end
 
-@testset "transverse coordiantes value" begin
+@testset "transverse coordinates value" begin
   @test isapprox(LorentzVectorBase.pt2(lvec_non_zero), x^2 + y^2)
   @test isapprox(LorentzVectorBase.pt(lvec_non_zero), sqrt(x^2 + y^2))
   @test isapprox(LorentzVectorBase.mt2(lvec_non_zero), t^2 - z^2)
@@ -117,7 +117,7 @@ end
   @test isapprox(LorentzVectorBase.eta(CustomLVector(0.0, 0.0, -1.0, 0.0)), -10e10)
 end
 
-@testset "spherical coordiantes consistence" for lvec in [lvec_non_zero, lvec_zero]
+@testset "spherical coordinates consistence" for lvec in [lvec_non_zero, lvec_zero]
   @test isapprox(
     LorentzVectorBase.cos_theta(lvec), cos(LorentzVectorBase.polar_angle(lvec))
   )
@@ -125,7 +125,7 @@ end
   @test isapprox(LorentzVectorBase.sin_phi(lvec), sin(LorentzVectorBase.phi(lvec)))
 end
 
-@testset "spherical coordiantes values" begin
+@testset "spherical coordinates values" begin
   @test isapprox(
     LorentzVectorBase.polar_angle(lvec_non_zero),
     atan(LorentzVectorBase.pt(lvec_non_zero), z),
@@ -136,7 +136,7 @@ end
   @test isapprox(LorentzVectorBase.phi(lvec_zero), 0.0)
 end
 
-@testset "light-cone coordiantes" begin
+@testset "light-cone coordinates" begin
   @test isapprox(LorentzVectorBase.plus_component(lvec_non_zero), 0.5 * (t + z))
   @test isapprox(LorentzVectorBase.minus_component(lvec_non_zero), 0.5 * (t - z))
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -22,7 +22,7 @@ LorentzVectorBase.coordinate_system(::TestMomentum) = TestCoordinteSystem()
   end
 end
 
-@testset "Aliasses" begin
+@testset "Aliases" begin
   mom = TestMomentum()
   @testset "$alias, $fun" for (alias, fun) in LorentzVectorBase.FOURMOMENTUM_GETTER_ALIASSES
     alias_result = eval(quote


### PR DESCRIPTION
Fixing a few small typos. Removing instruction about pre-commit since there is no pre-commit config for this repo. Also removing part about updating `Changelog.md` since it already isn't followed :upside_down_face: 

## Related issues

There is no related issue.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] Tests are passing
- [x] Docs were updated and workflow is passing
