### PR TITLE
Fix wrong arch for macos runner , update actions

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -29,7 +29,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: "1"

--- a/.github/workflows/Formatting.yml
+++ b/.github/workflows/Formatting.yml
@@ -5,9 +5,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - name: install Julia
-              uses: julia-actions/setup-julia@v1
+              uses: julia-actions/setup-julia@v2
               with:
                   version: "1.10"
             - name: Install Julia requirements

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -34,7 +34,7 @@ jobs:
         continue-on-error: ${{ inputs.allow_failure }}
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: julia-actions/setup-julia@v2
               with:
                   version: ${{ inputs.version }}
@@ -45,8 +45,8 @@ jobs:
             - uses: julia-actions/julia-runtest@v1
             - uses: julia-actions/julia-processcoverage@v1
               if: ${{ inputs.run_codecov }}
-            - uses: codecov/codecov-action@v4
+            - uses: codecov/codecov-action@v5
               if: ${{ inputs.run_codecov }}
               with:
-                  file: lcov.info
+                  files: lcov.info
                   token: ${{ secrets.codecov_token }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,11 +11,11 @@ jobs:
     test:
         uses: ./.github/workflows/ReusableTest.yml
         with:
-            os: ${{ matrix.os }}
+            os: ${{ matrix.platform.os }}
             version: ${{ matrix.version }}
-            arch: ${{ matrix.arch }}
+            arch: ${{ matrix.platform.arch }}
             allow_failure: ${{ matrix.allow_failure }}
-            run_codecov: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
+            run_codecov: ${{ matrix.version == '1' && matrix.platform.os == 'ubuntu-latest' }}
         secrets:
             codecov_token: ${{ secrets.CODECOV_TOKEN }}
         strategy:
@@ -24,10 +24,11 @@ jobs:
                 version:
                     - "lts"
                     - "1"
-                os:
-                    - ubuntu-latest
-                    - macOS-latest
-                    - windows-latest
-                arch:
-                    - x64
+                platform:
+                    - os: ubuntu-latest
+                      arch: x64
+                    - os: macOS-latest
+                      arch: aarch64
+                    - os: windows-latest
+                      arch: x64
                 allow_failure: [false]


### PR DESCRIPTION
<!--
Thanks for making a pull request to LorentzVectorBase.jl.
We have added this PR template to help you help us.

See the comments below, fill the required fields, and check the items.
-->

Fixing warning for macOS jobs:
```
test (1, macOS-latest, x64, false) / Julia 1 - macOS-latest - x64 - push
[setup-julia] x64 arch has been requested on a macOS runner that has an arm64 (Apple Silicon) architecture. You may have meant to use the "aarch64" arch instead (or left it unspecified for the correct default).
```
An alternative would be to remove the `arch` argument entirely and use the default but I guess we want to explicitly print the arch in job name

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->


<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
There is no related issue.


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] Tests are passing
- [x] Docs were updated and workflow is passing
