### PR TITLE
fix broken formatting in px and phi docs

### DIFF
--- a/src/getter.jl
+++ b/src/getter.jl
@@ -50,7 +50,7 @@ E
 Return the x-component of a given Lorentz-vector-like `lv`.
 
 # Example
-    For a four-momentum `(px, py, pz, E)`, this function returns the `px` component.
+For a four-momentum `(px, py, pz, E)`, this function returns the `px` component.
 
 # See Also
 - [`LorentzVectorBase.x`](@ref): The x-component of a Lorentz-vector-like, which is equivalent to `px`.
@@ -161,7 +161,7 @@ Return the azimuthal angle (``\\phi``) of the Lorentz-vector-like `lv`.
 The azimuthal angle is the angle between the x-axis and the projection of the Lorentz-vector-like on the x-y plane.
 
 # Example
-    If ``(x, y, z, t)`` is a four-vector, this is equivalent to ``atan(y / x)``.
+If ``(x, y, z, t)`` is a four-vector, this is equivalent to ``atan(y / x)``.
 
 !!! note
 

--- a/src/getter.jl
+++ b/src/getter.jl
@@ -365,7 +365,7 @@ where ``\\theta`` is the polar angle of the Lorentz-vector-like relative to the 
 
 
 # Example
-For a four-momentum `(px, py, pz, E)`, this function `log(tan(theta/2))` where `theta` is given by the [`polar_angle`](@ref).
+For a four-momentum `(px, py, pz, E)`, this function returns `log(tan(theta/2))` where `theta` is given by the [`polar_angle`](@ref).
 
 !!! warning
 


### PR DESCRIPTION
<!--
Thanks for making a pull request to LorentzVectorBase.jl.
We have added this PR template to help you help us.

See the comments below, fill the required fields, and check the items.
-->

<img width="756" height="621" alt="image" src="https://github.com/user-attachments/assets/f664fd52-4652-4615-81d9-a2d2b1e176f7" />

The formatting for `px` and `phi` was broken - creating code field for textual example

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->


<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] Tests are passing
- [x] Docs were updated and workflow is passing
